### PR TITLE
feat: 파일/디렉터리 검증 서비스 구현

### DIFF
--- a/internal/service/validation_dto.go
+++ b/internal/service/validation_dto.go
@@ -1,0 +1,74 @@
+// Package service provides business logic for DataLocker.
+// This file defines validation DTOs for files and directories.
+package service
+
+// ItemType 검증 대상 타입
+type ItemType string
+
+const (
+	ItemTypeFile      ItemType = "file"
+	ItemTypeDirectory ItemType = "directory"
+)
+
+// ValidationRequest 파일 또는 디렉터리 검증 요청
+type ValidationRequest struct {
+	Type ItemType `json:"type"` // "file" 또는 "directory"
+	Path string   `json:"path"` // 파일 경로 또는 디렉터리 경로
+
+	// 파일인 경우
+	FileName string `json:"file_name,omitempty"`
+	FileSize int64  `json:"file_size,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+
+	// 디렉터리인 경우
+	DirectoryPath string     `json:"directory_path,omitempty"`
+	Files         []FileInfo `json:"files,omitempty"` // 디렉터리 내 파일들
+}
+
+// FileInfo 파일 정보
+type FileInfo struct {
+	Name         string `json:"name"`
+	RelativePath string `json:"relative_path"` // 디렉터리 기준 상대 경로
+	Size         int64  `json:"size"`
+	MimeType     string `json:"mime_type"`
+}
+
+// ValidationResult 검증 결과
+type ValidationResult struct {
+	IsValid bool     `json:"is_valid"`
+	Type    ItemType `json:"type"`
+
+	// 전체 요약
+	TotalFiles   int      `json:"total_files"`
+	TotalSize    int64    `json:"total_size"`
+	ValidFiles   int      `json:"valid_files"`
+	InvalidFiles int      `json:"invalid_files"`
+	Errors       []string `json:"errors,omitempty"`
+
+	// 개별 파일 결과 (디렉터리인 경우)
+	FileResults []FileValidationResult `json:"file_results,omitempty"`
+}
+
+// FileValidationResult 개별 파일 검증 결과
+type FileValidationResult struct {
+	FileName     string   `json:"file_name"`
+	RelativePath string   `json:"relative_path"`
+	IsValid      bool     `json:"is_valid"`
+	Errors       []string `json:"errors,omitempty"`
+}
+
+// 제한 상수들
+const (
+	MaxFileSize      = 100 * 1024 * 1024  // 100MB
+	MaxDirectorySize = 1024 * 1024 * 1024 // 1GB (디렉터리 전체)
+	MaxFileCount     = 1000               // 디렉터리당 최대 파일 수
+	MinFileSize      = 1
+)
+
+// 허용된 MIME 타입 (기본적인 것만)
+var AllowedMimeTypes = []string{
+	"text/plain",
+	"application/pdf",
+	"image/jpeg",
+	"image/png",
+}

--- a/internal/service/validation_interface.go
+++ b/internal/service/validation_interface.go
@@ -1,0 +1,17 @@
+// Package service provides business logic for DataLocker.
+// This file defines validation interface for files and directories.
+package service
+
+import "context"
+
+// ValidationService 파일/디렉터리 검증 서비스
+type ValidationService interface {
+	// ValidateItem 파일 또는 디렉터리를 검증합니다
+	ValidateItem(ctx context.Context, req *ValidationRequest) (*ValidationResult, error)
+
+	// ValidateFile 단일 파일만 검증 (기존 호환성)
+	ValidateFile(ctx context.Context, fileName string, fileSize int64, mimeType string) (*FileValidationResult, error)
+
+	// ValidateDirectory 디렉터리 전체를 검증
+	ValidateDirectory(ctx context.Context, directoryPath string, files []FileInfo) (*ValidationResult, error)
+}

--- a/internal/service/validation_service.go
+++ b/internal/service/validation_service.go
@@ -1,0 +1,159 @@
+// Package service provides business logic for DataLocker.
+// This file implements file and directory validation.
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// validationService 파일/디렉터리 검증 서비스 구현체
+type validationService struct{}
+
+// NewValidationService 새로운 검증 서비스를 생성합니다
+func NewValidationService() ValidationService {
+	return &validationService{}
+}
+
+// ValidateItem 파일 또는 디렉터리를 검증합니다
+func (s *validationService) ValidateItem(ctx context.Context, req *ValidationRequest) (*ValidationResult, error) {
+	switch req.Type {
+	case ItemTypeFile:
+		return s.validateSingleFile(req)
+	case ItemTypeDirectory:
+		return s.validateDirectoryInternal(req)
+	default:
+		return nil, fmt.Errorf("지원하지 않는 타입입니다: %s", req.Type)
+	}
+}
+
+// ValidateFile 단일 파일 검증 (기존 호환성)
+func (s *validationService) ValidateFile(ctx context.Context, fileName string, fileSize int64, mimeType string) (*FileValidationResult, error) {
+	result := &FileValidationResult{
+		FileName: fileName,
+		IsValid:  true,
+		Errors:   make([]string, 0),
+	}
+
+	// 기본 검증들
+	if fileName == "" {
+		result.IsValid = false
+		result.Errors = append(result.Errors, "파일명이 비어있습니다")
+	}
+
+	if fileSize <= MinFileSize {
+		result.IsValid = false
+		result.Errors = append(result.Errors, "파일이 너무 작습니다")
+	}
+
+	if fileSize > MaxFileSize {
+		result.IsValid = false
+		result.Errors = append(result.Errors, "파일이 너무 큽니다")
+	}
+
+	if !s.isAllowedMimeType(mimeType) {
+		result.IsValid = false
+		result.Errors = append(result.Errors, "지원하지 않는 파일 형식입니다")
+	}
+
+	return result, nil
+}
+
+// ValidateDirectory 디렉터리 전체를 검증
+func (s *validationService) ValidateDirectory(ctx context.Context, directoryPath string, files []FileInfo) (*ValidationResult, error) {
+	result := &ValidationResult{
+		Type:        ItemTypeDirectory,
+		IsValid:     true,
+		TotalFiles:  len(files),
+		FileResults: make([]FileValidationResult, 0),
+		Errors:      make([]string, 0),
+	}
+
+	// 1. 디렉터리 기본 검증
+	if directoryPath == "" {
+		result.IsValid = false
+		result.Errors = append(result.Errors, "디렉터리 경로가 비어있습니다")
+		return result, nil
+	}
+
+	// 2. 파일 개수 제한
+	if len(files) > MaxFileCount {
+		result.IsValid = false
+		result.Errors = append(result.Errors, fmt.Sprintf("파일이 너무 많습니다 (최대 %d개)", MaxFileCount))
+	}
+
+	// 3. 각 파일 검증
+	var totalSize int64
+	for _, file := range files {
+		fileResult, err := s.ValidateFile(ctx, file.Name, file.Size, file.MimeType)
+		if err != nil {
+			continue // 에러난 파일은 건너뛰기
+		}
+
+		fileResult.RelativePath = file.RelativePath
+		result.FileResults = append(result.FileResults, *fileResult)
+
+		totalSize += file.Size
+
+		if fileResult.IsValid {
+			result.ValidFiles++
+		} else {
+			result.InvalidFiles++
+			result.IsValid = false // 하나라도 실패하면 전체 실패
+		}
+	}
+
+	// 4. 전체 크기 검증
+	result.TotalSize = totalSize
+	if totalSize > MaxDirectorySize {
+		result.IsValid = false
+		result.Errors = append(result.Errors, "디렉터리 전체 크기가 너무 큽니다")
+	}
+
+	return result, nil
+}
+
+// 내부 헬퍼 메서드들
+
+// validateSingleFile 단일 파일 검증 (내부용)
+func (s *validationService) validateSingleFile(req *ValidationRequest) (*ValidationResult, error) {
+	fileResult, err := s.ValidateFile(context.Background(), req.FileName, req.FileSize, req.MimeType)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ValidationResult{
+		Type:         ItemTypeFile,
+		IsValid:      fileResult.IsValid,
+		TotalFiles:   1,
+		TotalSize:    req.FileSize,
+		ValidFiles:   0,
+		InvalidFiles: 0,
+		Errors:       fileResult.Errors,
+		FileResults:  []FileValidationResult{*fileResult},
+	}
+
+	if fileResult.IsValid {
+		result.ValidFiles = 1
+	} else {
+		result.InvalidFiles = 1
+	}
+
+	return result, nil
+}
+
+// validateDirectoryInternal 디렉터리 검증 (내부용)
+func (s *validationService) validateDirectoryInternal(req *ValidationRequest) (*ValidationResult, error) {
+	return s.ValidateDirectory(context.Background(), req.DirectoryPath, req.Files)
+}
+
+// isAllowedMimeType 허용된 MIME 타입인지 확인
+func (s *validationService) isAllowedMimeType(mimeType string) bool {
+	for _, allowed := range AllowedMimeTypes {
+		if strings.EqualFold(mimeType, allowed) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#16

## 📝작업 내용

- **단일 파일 검증**: 파일명, 크기, MIME 타입 검증
- **디렉터리 전체 검증**: 여러 파일 일괄 처리
- **제한 조건**: 
  - 파일 크기: 최대 100MB
  - 디렉터리: 최대 1GB, 1000개 파일
  - 허용 MIME: text/plain, PDF, JPEG, PNG
- **상대 경로 보존**: 디렉터리 구조 유지